### PR TITLE
[FEAT] toss payments 테스트 구현

### DIFF
--- a/src/app/api/payments/confirm-payment/route.ts
+++ b/src/app/api/payments/confirm-payment/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { paymentKey, orderId, amount } = await request.json();
+
+    const response = await axios.post(
+      "https://api.tosspayments.com/v1/payments/confirm",
+      {
+        paymentKey,
+        orderId,
+        amount: Number(amount),
+      },
+      {
+        headers: {
+          Authorization: `Basic ${Buffer.from(`${process.env.TOSS_SECRET_KEY}:`).toString(
+            "base64"
+          )}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    return NextResponse.json({ success: true, paymentInfo: response.data });
+  } catch (error: any) {
+    console.error("결제 승인 실패", error.response?.data);
+    return NextResponse.json({ success: false, error: error.response?.data }, { status: 400 });
+  }
+}

--- a/src/app/fail/page.tsx
+++ b/src/app/fail/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export default function Fail() {
+  const searchParams = useSearchParams();
+  const message = searchParams.get("message") || "결제 실패";
+
+  return (
+    <div>
+      <h1>결제 실패</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import TossPayment from "../components/TossPayment";
 
 export default function Home() {
   const [message, setMessage] = useState("");
@@ -29,6 +30,10 @@ export default function Home() {
         <strong>GPT 응답:</strong>
         <p>{reply}</p>
       </div>
+
+      <hr style={{ margin: "40px 0" }} />
+
+      <TossPayment />
     </main>
   );
 }

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function Success() {
+  const searchParams = useSearchParams();
+  const [message, setMessage] = useState("결제 승인 중입니다...");
+
+  useEffect(() => {
+    async function confirmPayment() {
+      const paymentKey = searchParams.get("paymentKey");
+      const orderId = searchParams.get("orderId");
+      const amount = searchParams.get("amount");
+
+      if (!paymentKey || !orderId || !amount) {
+        setMessage("결제 정보가 올바르지 않습니다.");
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/payments/confirm-payment", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ paymentKey, orderId, amount }),
+        });
+
+        const data = await res.json();
+
+        if (res.ok && data.success) {
+          setMessage("결제가 성공적으로 완료되었습니다!");
+        } else {
+          setMessage("결제 승인에 실패했습니다: " + (data.error?.message || "알 수 없는 오류"));
+        }
+      } catch (error) {
+        setMessage("서버와 통신 중 오류가 발생했습니다.");
+      }
+    }
+
+    confirmPayment();
+  }, [searchParams]);
+
+  return (
+    <div>
+      <h1>결제 결과</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/src/components/TossPayment.tsx
+++ b/src/components/TossPayment.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useEffect } from "react";
+
+export default function TossPayment() {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://js.tosspayments.com/v1";
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  const handlePayment = () => {
+    const tossPayments = (window as any).TossPayments(process.env.NEXT_PUBLIC_CLIENT_KEY);
+
+    tossPayments.requestPayment("카드", {
+      amount: 5000,
+      orderId: "order_" + new Date().getTime(),
+      orderName: "토스 결제 테스트",
+      customerName: "홍길동",
+      successUrl: "http://localhost:3000/success",
+      failUrl: "http://localhost:3000/fail",
+    });
+  };
+
+  return (
+    <div>
+      <h2>토스 결제 테스트</h2>
+      <button onClick={handlePayment}>결제하기</button>
+    </div>
+  );
+}


### PR DESCRIPTION
 #2 

토스 결제창 테스트 구현
토스 개발자센터에서 테스트용 api 발급 후, `.env.local`에 넣어서 테스트

![image](https://github.com/user-attachments/assets/4da1d743-db33-47ea-acbe-910a4e0273bf)

TOSS_SECRET_KEY = 시크릿 키
NEXT_PUBLIC_CLIENT_KEY = 클라이언트 키